### PR TITLE
Ptp fix

### DIFF
--- a/brpylib/brpylib.py
+++ b/brpylib/brpylib.py
@@ -28,7 +28,7 @@ v2.0.0 - 04/27/2021 - numpy-based architecture rebuild of NevFile.getdata()
 v2.0.1 - 11/12/2021 - fixed indexing error in NevFile.getdata()
                       Added numpy architecture to NsxFile.getdata()
 v2.0.2 - 03/21/2023 - added logic to NsxFile.getdata() for where PTP timestamps are applied to every continuous sample
-                      created method 'samplealign' in class NsxFile
+                      created method 'getaligneddata' in class NsxFile
 """
 
 

--- a/brpylib/brpylib.py
+++ b/brpylib/brpylib.py
@@ -1453,7 +1453,7 @@ class NsxFile:
 
         return output
 
-    def samplealign(
+    def getaligneddata(
             self,
             elec_ids="all",
             start_time_s=0,

--- a/brpylib/brpylib.py
+++ b/brpylib/brpylib.py
@@ -42,7 +42,7 @@ from struct import calcsize, pack, unpack, unpack_from
 
 import numpy as np
 
-from brMiscFxns import brmiscfxns_ver, openfilecheck
+from .brMiscFxns import brmiscfxns_ver, openfilecheck
 
 # Version control set/check
 brpylib_ver = "2.0.2"


### PR DESCRIPTION
This is a pull request for merging in changes to the class `NsxFile` to allow for files with 1-sample segments in continuous data. This allows for PTP timestamping of continuous data.
The method `getaligneddata()` allows for continuous data frame copies/removals to allow for PTP-timestamped data to be aligned to the "true" sampling rates (30 kS/s, 10 kS/s, etc). This allows data recorded from a Gemini NSP and Gemini Hub to be aligned for analysis after alignment.