### PR TITLE
"with" compatibility for NsxFile and NevFile

### DIFF
--- a/brpylib/brpylib.py
+++ b/brpylib/brpylib.py
@@ -1009,7 +1009,7 @@ class NevFile:
         
     # add "enter" and "exit" methods for compatibility with "with":
     def __enter__(self):
-        pass
+        return self
     
     def __exit__(self,*args):
         self.close()
@@ -1736,7 +1736,7 @@ class NsxFile:
         
     # add "enter" and "exit" methods for compatibility with "with":
     def __enter__(self):
-        pass
+        return self
     
     def __exit__(self,*args):
         self.close()

--- a/brpylib/brpylib.py
+++ b/brpylib/brpylib.py
@@ -507,7 +507,10 @@ class NevFile:
         self.datafile = datafile
         self.basic_header = {}
         self.extended_headers = []
-
+        
+        self.openfile()
+        
+    def openfile(self):
         # Run openfilecheck and open the file passed or allow user to browse to one
         self.datafile = openfilecheck(
             "rb",
@@ -1003,6 +1006,13 @@ class NevFile:
         name = self.datafile.name
         self.datafile.close()
         print("\n" + name.split("/")[-1] + " closed")
+        
+    # add "enter" and "exit" methods for compatibility with "with":
+    def __enter__(self):
+        pass
+    
+    def __exit__(self,*args):
+        self.close()
 
 
 class NsxFile:
@@ -1016,7 +1026,10 @@ class NsxFile:
         self.datafile = datafile
         self.basic_header = {}
         self.extended_headers = []
-
+        
+        self.openfile()
+        
+    def openfile(self):
         # Run openfilecheck and open the file passed or allow user to browse to one
         self.datafile = openfilecheck(
             "rb",
@@ -1720,3 +1733,10 @@ class NsxFile:
         name = self.datafile.name
         self.datafile.close()
         print("\n" + name.split("/")[-1] + " closed")
+        
+    # add "enter" and "exit" methods for compatibility with "with":
+    def __enter__(self):
+        pass
+    
+    def __exit__(self,*args):
+        self.close()

--- a/brpylib/brpylib.py
+++ b/brpylib/brpylib.py
@@ -1009,7 +1009,7 @@ class NevFile:
         
     # add "enter" and "exit" methods for compatibility with "with":
     def __enter__(self):
-        return self
+        return self # thankfully this returns a reference, not a copy
     
     def __exit__(self,*args):
         self.close()
@@ -1736,7 +1736,7 @@ class NsxFile:
         
     # add "enter" and "exit" methods for compatibility with "with":
     def __enter__(self):
-        return self
+        return self # thankfully this returns a reference, not a copy 
     
     def __exit__(self,*args):
         self.close()


### PR DESCRIPTION
Added simply __enter__ and __exit__ methods to the NsxFile and NevFile objects, which allows users to manage these file streams using the typical "with" statement. 