### PR TITLE
Fix comment parsing

### DIFF
--- a/brpylib/brpylib.py
+++ b/brpylib/brpylib.py
@@ -736,12 +736,13 @@ class NevFile:
             )
             trueCommentsidx = np.asarray(commentPackets)[trueComments]
             textComments = comments[trueCommentsidx]
-            textComments[:, -1] = "$"
-            stringarray = textComments.tostring()
-            stringvector = stringarray.decode("latin-1")
-            stringvector = stringvector[0:-1]
-            validstrings = stringvector.replace("\x00", "")
-            commentsFinal = validstrings.split("$")
+            commentsFinal = []
+            for text in textComments:
+                stringarray = text.tostring()
+                stringvector = stringarray.decode("latin-1")
+                stringvector = stringvector[0:-1]
+                validstring = stringvector.replace("\x00", "")
+                commentsFinal.append(validstring)
 
             # Remove the ROI comments from the list
             subsetInds = list(


### PR DESCRIPTION
Addresses Issue #34 

Comments are now parsed out of binary and cleaned up individually, meaning that $ is no longer treated as a special character.
Behavior is unchanged for comments that do not contain $