### PR TITLE
Specify outfile

### DIFF
--- a/brpylib/brMiscFxns.py
+++ b/brpylib/brMiscFxns.py
@@ -28,17 +28,19 @@ except NameError:
     pass
 
 
-def openfilecheck(open_mode, file_name="", file_ext="", file_type=""):
+def openfilecheck(open_mode, file_name="", file_ext="", file_type="", verbose=True, interactive=True):
     """
     :param open_mode: {str} method to open the file (e.g., 'rb' for binary read only)
     :param file_name: [optional] {str} full path of file to open
     :param file_ext:  [optional] {str} file extension (e.g., '.nev')
     :param file_type: [optional] {str} file type for use when browsing for file (e.g., 'Blackrock NEV Files')
+    :param verbose: [optional] {bool} whether or not to print status information
+    :param interactive: [optional] {bool} will only try to prompt user for a file if True, otherwise allow failure
     :return: {file} opened file
     """
 
     while True:
-        if not file_name:  # no file name passed
+        if interactive and not file_name:  # no file name passed
             if not HAS_QT:
                 raise ModuleNotFoundError(
                     "Qt required for file dialog. Install PySide + qtpy or provide file_name."
@@ -63,7 +65,7 @@ def openfilecheck(open_mode, file_name="", file_ext="", file_type=""):
                 file_name = file_name[0]
 
         # Ensure file exists (really needed for users type entering)
-        if path.isfile(file_name):
+        if interactive and path.isfile(file_name):
             # Ensure given file matches file_ext
             if file_ext:
                 _, fext = path.splitext(file_name)
@@ -86,8 +88,9 @@ def openfilecheck(open_mode, file_name="", file_ext="", file_type=""):
         else:
             file_name = ""
             print("\n*** File given does exist, try again ***\n")
+    if verbose:
+        print("\n" + file_name.split("/")[-1] + " opened")
 
-    print("\n" + file_name.split("/")[-1] + " opened")
     return open(file_name, open_mode)
 
 

--- a/brpylib/brMiscFxns.py
+++ b/brpylib/brMiscFxns.py
@@ -65,7 +65,7 @@ def openfilecheck(open_mode, file_name="", file_ext="", file_type="", verbose=Tr
                 file_name = file_name[0]
 
         # Ensure file exists (really needed for users type entering)
-        if interactive and path.isfile(file_name):
+        if path.isfile(file_name):
             # Ensure given file matches file_ext
             if file_ext:
                 _, fext = path.splitext(file_name)
@@ -77,13 +77,16 @@ def openfilecheck(open_mode, file_name="", file_ext="", file_type="", verbose=Tr
                     test_extension = file_ext
 
                 if fext[0 : len(test_extension)] != test_extension:
-                    file_name = ""
-                    print(
-                        "\n*** File given is not a "
-                        + file_ext
-                        + " file, try again ***\n"
-                    )
-                    continue
+                    if interactive:
+                        file_name = ""
+                        print(
+                            "\n*** File given is not a "
+                            + file_ext
+                            + " file, try again ***\n"
+                        )
+                        continue
+                    else:
+                        break
             break
         else:
             file_name = ""

--- a/brpylib/brpylib.py
+++ b/brpylib/brpylib.py
@@ -1335,7 +1335,7 @@ class NsxFile:
         return output
 
     def savesubsetnsx(
-        self, elec_ids="all", file_size=None, file_time_s=None, file_suffix=""
+        self, elec_ids="all", file_size=None, file_time_s=None, file_suffix="", out_file=""
     ):
         """
         This function is used to save a subset of data based on electrode IDs, file sizing, or file data time.  If
@@ -1348,6 +1348,7 @@ class NsxFile:
                                                    nothing is passed, file_size will be used as default.
         :param file_suffix: [optional] {str}   Suffix to append to NSx datafile name for subset files.  If nothing is
                                                    passed, default will be "_subset".
+        :param out_file: [optional] {str}  Full path to where to save the subset file (supersedes file_suffix).
         :return: None - None of the electrodes requested exist in the data
                  SUCCESS - All file subsets extracted and saved
         """
@@ -1405,18 +1406,20 @@ class NsxFile:
             file_size = check_filesize(file_size)
 
         # Create and open subset file as writable binary, if it already exists ask user for overwrite permission
-        file_name, file_ext = ospath.splitext(self.datafile.name)
-        if file_suffix:
-            file_name += "_" + file_suffix
+        if out_file:
+            new_file_name = out_file
         else:
-            file_name += "_subset"
+            file_name, file_ext = ospath.splitext(self.datafile.name)
+            if file_suffix:
+                file_name += "_" + file_suffix
+            else:
+                file_name += "_subset"
+            new_file_name = file_name + "_000" + file_ext
 
-        if ospath.isfile(file_name + "_000" + file_ext):
+        if ospath.isfile(new_file_name):
             if "y" != input(
                 "\nFile '"
-                + file_name.split("/")[-1]
-                + "_xxx"
-                + file_ext
+                + new_file_name
                 + "' already exists, overwrite [y/n]: "
             ):
                 print("\nExiting, no overwrite, returning None")
@@ -1424,7 +1427,7 @@ class NsxFile:
             else:
                 print("\n*** Overwriting existing subset files ***")
 
-        subset_file = open(file_name + "_000" + file_ext, "wb")
+        subset_file = open(new_file_name, "wb")
         print("\nWriting subset file: " + ospath.split(subset_file.name)[1])
 
         # For file spec 2.1:

--- a/brpylib/brpylib.py
+++ b/brpylib/brpylib.py
@@ -512,7 +512,7 @@ class NevFile:
     basic header information.
     """
 
-    def __init__(self, datafile=""):
+    def __init__(self, datafile="", verbose=True, interactive=True):
         self.datafile = datafile
         self.basic_header = {}
         self.extended_headers = []
@@ -523,6 +523,8 @@ class NevFile:
             file_name=self.datafile,
             file_ext=".nev",
             file_type="Blackrock NEV Files",
+            verbose=verbose,
+            interactive=interactive
         )
 
         # extract basic header information
@@ -1020,7 +1022,7 @@ class NsxFile:
     basic header information.
     """
 
-    def __init__(self, datafile=""):
+    def __init__(self, datafile="", interactive=True, verbose=True):
 
         self.datafile = datafile
         self.basic_header = {}
@@ -1032,6 +1034,8 @@ class NsxFile:
             file_name=self.datafile,
             file_ext=".ns*",
             file_type="Blackrock NSx Files",
+            interactive=interactive,
+            verbose=verbose
         )
 
         # Determine File ID to determine if File Spec 2.1
@@ -1219,11 +1223,8 @@ class NsxFile:
                     # memmap moves the file pointer inconsistently depending on platform and numpy version
                     curr_loc = self.datafile.tell()
                     expected_loc = bod + num_data_pts * data_pt_size
-                    if curr_loc == bod:
-                        # It did not move the pointer at all. Move it manually.
-                        self.datafile.seek(expected_loc - bod, 1)
-                    elif curr_loc > expected_loc:
-                        # Moved it too far (probably to end of file); move manually from beginning to expected.
+                    if curr_loc != expected_loc:
+                        # memmap moved the cursor to an unexpected location, update it manually
                         self.datafile.seek(expected_loc, 0)
             else:
                 # 1 sample per packet. Reuse struct_arr.


### PR DESCRIPTION
Add an option to the NsXFile save_subset function to explicitly specify a new output path, instead of being constrained to the subset naming convention.